### PR TITLE
drive subsystem code including ramsete functionality methods

### DIFF
--- a/Competition/src/main/cpp/Drivetrain.cpp
+++ b/Competition/src/main/cpp/Drivetrain.cpp
@@ -22,12 +22,6 @@ Drivetrain::Drivetrain() : boostMultiplier{DriveConstants::kNoBoost},
                            m_odometry{frc::Rotation2d(units::degree_t(GetHeading()))},
                            limelight_state{LimelightConstants::STATE_ON} // Init as on so it immediately will turn off in the state machine
 {
-  m_leftPIDController = m_leftDriveLead.GetPIDController();
-  m_rightPIDController = m_rightDriveLead.GetPIDController();
-
-  m_leftEncoder = m_leftDriveLead.GetEncoder();
-  m_rightEncoder = m_rightDriveLead.GetEncoder();
-
   kTrajectoryConfigF.SetKinematics(kDriveKinematics);
   kTrajectoryConfigF.AddConstraint(kDifferentialDriveVoltageConstraint);
   kTrajectoryConfigF.SetReversed(false);

--- a/Competition/src/main/cpp/Drivetrain.cpp
+++ b/Competition/src/main/cpp/Drivetrain.cpp
@@ -7,15 +7,231 @@
 
 #include "Drivetrain.h"
 
-Drivetrain::Drivetrain() {}
-
-Drivetrain& Drivetrain::GetInstance()
+Drivetrain::Drivetrain() : boostMultiplier{0.5},
+                           kDriveKinematics{DriveConstants::kTrackwidth},
+                           kSimpleMotorFeedforward{RamseteConstants::kS, RamseteConstants::kV, RamseteConstants::kA},
+                           kTrajectoryConfigF{RamseteConstants::kMaxSpeed, RamseteConstants::kMaxAcceleration},
+                           kTrajectoryConfigR{RamseteConstants::kMaxSpeed, RamseteConstants::kMaxAcceleration},
+                           kDifferentialDriveVoltageConstraint{kSimpleMotorFeedforward, kDriveKinematics, 10_V},
+                           m_leftDriveLead{DriveConstants::CAN_ID_LEFT_LEAD, rev::CANSparkMax::MotorType::kBrushless},
+                           m_leftDriveFollowA{DriveConstants::CAN_ID_LEFT_FOLLOW_A, rev::CANSparkMax::MotorType::kBrushless},
+                           m_leftDriveFollowB{DriveConstants::CAN_ID_LEFT_FOLLOW_B, rev::CANSparkMax::MotorType::kBrushless},
+                           m_rightDriveLead{DriveConstants::CAN_ID_RIGHT_LEAD, rev::CANSparkMax::MotorType::kBrushless},
+                           m_rightDriveFollowA{DriveConstants::CAN_ID_RIGHT_FOLLOW_A, rev::CANSparkMax::MotorType::kBrushless},
+                           m_rightDriveFollowB{DriveConstants::CAN_ID_RIGHT_FOLLOW_B, rev::CANSparkMax::MotorType::kBrushless},
+                           m_odometry{frc::Rotation2d(units::degree_t(GetHeading()))},
+                           limelight_state{1} // Init as on so it immediately will turn off in the state machine
 {
-  // Guaranteed to be destroyed. Instantiated on first use.
+  kTrajectoryConfigF.SetKinematics(kDriveKinematics);
+  kTrajectoryConfigF.AddConstraint(kDifferentialDriveVoltageConstraint);
+  kTrajectoryConfigF.SetReversed(false);
+
+  kTrajectoryConfigR.SetKinematics(kDriveKinematics);
+  kTrajectoryConfigR.AddConstraint(kDifferentialDriveVoltageConstraint);
+  kTrajectoryConfigR.SetReversed(true);
+
+  imu.Calibrate();
+
+  InitDrives(rev::CANSparkMax::IdleMode::kCoast);
+}
+Drivetrain& Drivetrain::GetInstance() {
   static Drivetrain instance;
   return instance;
 }
 
 void Drivetrain::Periodic() {
-  // Update odometry
+  m_odometry.Update(frc::Rotation2d(units::degree_t(GetHeading())), GetLeftDistance(), GetRightDistance());
+  frc::SmartDashboard::PutNumber("Heading", imu.GetAngle());
+}
+
+void Drivetrain::InitDrives(rev::CANSparkMax::IdleMode idleMode) {
+  m_leftDriveLead.RestoreFactoryDefaults();
+  m_leftDriveFollowA.RestoreFactoryDefaults();
+  m_leftDriveFollowB.RestoreFactoryDefaults();
+  m_rightDriveLead.RestoreFactoryDefaults();
+  m_rightDriveFollowA.RestoreFactoryDefaults();
+  m_rightDriveFollowB.RestoreFactoryDefaults();
+
+  m_leftDriveLead.SetIdleMode(idleMode);
+  m_leftDriveFollowA.SetIdleMode(idleMode);
+  m_leftDriveFollowB.SetIdleMode(idleMode);
+  m_rightDriveLead.SetIdleMode(idleMode);
+  m_rightDriveFollowA.SetIdleMode(idleMode);
+  m_rightDriveFollowB.SetIdleMode(idleMode);
+
+  m_leftDriveLead.Follow(rev::CANSparkMax::kFollowerDisabled, false);
+  m_rightDriveLead.Follow(rev::CANSparkMax::kFollowerDisabled, false);
+
+  m_leftDriveFollowA.Follow(m_leftDriveLead);
+  m_leftDriveFollowB.Follow(m_leftDriveLead);
+
+  m_rightDriveFollowA.Follow(m_rightDriveLead);
+  m_rightDriveFollowB.Follow(m_rightDriveLead);
+
+  m_leftPIDController.SetP(DriveConstants::kP);
+  m_leftPIDController.SetI(DriveConstants::kI);
+  m_leftPIDController.SetD(DriveConstants::kD);
+  m_leftPIDController.SetIZone(DriveConstants::kIz);
+  m_leftPIDController.SetFF(DriveConstants::kFF);
+  m_leftPIDController.SetOutputRange(DriveConstants::kMinOutput, DriveConstants::kMaxOutput);
+
+  m_rightPIDController.SetP(DriveConstants::kP);
+  m_rightPIDController.SetI(DriveConstants::kI);
+  m_rightPIDController.SetD(DriveConstants::kD);
+  m_rightPIDController.SetIZone(DriveConstants::kIz);
+  m_rightPIDController.SetFF(DriveConstants::kFF);
+  m_rightPIDController.SetOutputRange(DriveConstants::kMinOutput, DriveConstants::kMaxOutput);
+
+  m_rightPIDController.SetSmartMotionMaxVelocity(DriveConstants::kMaxVel);
+  m_rightPIDController.SetSmartMotionMinOutputVelocity(DriveConstants::kMinVel);
+  m_rightPIDController.SetSmartMotionMaxAccel(DriveConstants::kMaxAccel);
+  m_rightPIDController.SetSmartMotionAllowedClosedLoopError(DriveConstants::kAllError);
+  
+  m_leftPIDController.SetSmartMotionMaxVelocity(DriveConstants::kMaxVel);
+  m_leftPIDController.SetSmartMotionMinOutputVelocity(DriveConstants::kMinVel);
+  m_leftPIDController.SetSmartMotionMaxAccel(DriveConstants::kMaxAccel);
+  m_leftPIDController.SetSmartMotionAllowedClosedLoopError(DriveConstants::kAllError);
+
+  m_leftDriveLead.SetInverted(false);
+  m_rightDriveLead.SetInverted(true);
+}
+
+void Drivetrain::ResetEncoders() {
+  m_leftEncoder.SetPosition(0);
+  m_rightEncoder.SetPosition(0);
+}
+
+void Drivetrain::ResetOdometry(frc::Pose2d pose) {
+  ResetEncoders();
+  m_odometry.ResetPosition(pose, frc::Rotation2d(units::degree_t(GetHeading())));
+}
+void Drivetrain::ResetIMU() {
+  imu.Reset();
+}
+
+// rev::CANEncoder& GetLeftEncoder() {
+//     return m_leftEncoder;
+// }
+
+// rev::CANEncoder& GetRightEncoder() {
+//     return m_rightEncoder;
+// }
+
+double Drivetrain::GetEncAvgDistance() {
+  return ((m_leftEncoder.GetPosition() * RamseteConstants::kPositionConversionFactor) + (m_rightEncoder.GetPosition() * RamseteConstants::kPositionConversionFactor)) / 2.0;
+}
+
+units::meter_t Drivetrain::GetLeftDistance() {
+  return m_leftEncoder.GetPosition() * RamseteConstants::kPositionConversionFactor * 1_m;
+}
+
+units::meter_t Drivetrain::GetRightDistance() {
+  return m_rightEncoder.GetPosition() * RamseteConstants::kPositionConversionFactor * 1_m;
+}
+
+double Drivetrain::GetHeading() {
+  return std::remainder(imu.GetAngle(), 360) * (RamseteConstants::kGyroReversed ? -1.0 : 1.0);
+}
+
+double Drivetrain::GetTurnRate() {
+  return imu.GetRate() * (RamseteConstants::kGyroReversed ? -1.0 : 1.0);
+}
+
+frc::Pose2d Drivetrain::GetPose() { 
+  return m_odometry.GetPose(); 
+}
+
+frc::DifferentialDriveWheelSpeeds Drivetrain::GetWheelSpeeds() {
+  return { units::meters_per_second_t(m_leftEncoder.GetVelocity() * RamseteConstants::kVelocityConversionFactor),
+            units::meters_per_second_t(m_rightEncoder.GetVelocity() * RamseteConstants::kVelocityConversionFactor) };
+}
+
+void Drivetrain::TankDriveVolts(units::volt_t leftVolts, units::volt_t rightVolts) {
+  m_leftDriveLead.SetVoltage(leftVolts);
+  m_rightDriveLead.SetVoltage(rightVolts);
+  // m_drive.Feed();
+}
+
+void Drivetrain::ArcadeDrive(double leftInput, double rightInput) {
+  // drive.ArcadeDrive(leftInput, -rightInput * .5, true);
+}
+
+void Drivetrain::RocketLeagueDrive(double straightInput, double reverseInput, double turnInput, bool limelightInput) {
+  straightValue = reverseInput - straightInput;
+  if (std::abs(straightValue) < DriveConstants::kDeadbandY) {
+    straightValue = 0;
+  }
+  directionY = (straightValue >= 0) ? 1 : -1;
+  straightTarget = DriveConstants::MAX_RPM * -std::pow(straightValue, 2) * directionY * DriveConstants::kDriveMultiplierY * boostMultiplier;
+  
+  turnValue = turnInput;
+
+  directionX = (turnValue >= 0) ? 1 : -1;
+  turnValue = std::pow(turnValue * DriveConstants::kDriveMultiplierX, 2) * directionX;
+  turnTarget = DriveConstants::MAX_RPM * -turnValue;
+  // if (directionY == 1) {   //for inverting x and y in revese direction
+  //   turnTarget = -turnTarget;
+  // }
+
+  if (std::abs(turnValue) < DriveConstants::kDeadbandX) {
+    if (std::abs(straightValue) < DriveConstants::kDeadbandY) {
+      turnTarget = 0; //if turning, don't use drive straightening
+    }
+    else {
+      turnTarget = (m_leftEncoder.GetVelocity() - m_rightEncoder.GetVelocity()) * DriveConstants::kDriveOffset;
+      // Robot tends to curve to the left at 50RPM slower
+    }
+  }
+
+  std::shared_ptr<NetworkTable> table = nt::NetworkTableInstance::GetDefault().GetTable("limelight");
+  float tx = table->GetNumber("tx", 0.0);
+  float tv = table->GetNumber("tv" , 0.0);
+
+  // Limelight button pressed
+  if (limelightInput) {
+
+      // Check state of limelight
+      // If previously was off, turn on LED and start tracking
+      //if (limelight_state == 0) {
+          table->PutNumber("ledMode", LimelightConstants::LED_MODE_ON);
+          table->PutNumber("camMode", LimelightConstants::TRACK_MODE_ON);
+          limelight_state = 1;
+      //}
+
+      // Limelight has target, track and move robot
+      if (tv == 1) {
+        turnTarget = DriveConstants::kP * tx * DriveConstants::MAX_RPM;
+      } 
+      else {
+
+      // Check state of limelight
+      // If previously was on, turn off LED and stop tracking
+      // if (limelight_state == 1) {
+          table->PutNumber("ledMode", LimelightConstants::LED_MODE_OFF);
+          table->PutNumber("camMode", LimelightConstants::TRACK_MODE_OFF);
+          limelight_state = 0;
+      //}
+      }
+  }
+
+  m_leftPIDController.SetReference(straightTarget - turnTarget, rev::ControlType::kVelocity);
+  m_rightPIDController.SetReference(straightTarget + turnTarget, rev::ControlType::kVelocity);
+  
+  frc::SmartDashboard::PutNumber("TurnVelocity", turnTarget);
+  frc::SmartDashboard::PutNumber("ForwardVelocity", straightTarget);
+  frc::SmartDashboard::PutNumber("LeftVelocityVariable", m_leftEncoder.GetVelocity());
+  frc::SmartDashboard::PutNumber("RightVelocityVariable", m_rightEncoder.GetVelocity());
+}
+
+void Drivetrain::SetMultiplier(double multiplier) {
+  boostMultiplier = multiplier;
+}
+
+void Drivetrain::Stop() {
+  m_leftDriveLead.StopMotor();
+  m_leftDriveFollowA.StopMotor();
+  m_leftDriveFollowB.StopMotor();
+  m_rightDriveLead.StopMotor();
+  m_rightDriveFollowA.StopMotor();
+  m_rightDriveFollowB.StopMotor();
 }

--- a/Competition/src/main/include/Constants.h
+++ b/Competition/src/main/include/Constants.h
@@ -51,11 +51,14 @@ namespace DriveConstants {
     constexpr static double kMaxAccel = 1500;
     constexpr static double kAllError = 0;
     constexpr static double kDeadband = 0.05;
+
     constexpr static double kDeadbandY = 0.05;
     constexpr static double kDeadbandX = 0.05;
     constexpr static double kDriveMultiplierX = 0.5;
     constexpr static double kDriveMultiplierY = 1;
     constexpr static double kDriveOffset = 1;
+    constexpr static double kNoBoost = 0.5;
+    constexpr static double kBoost = 1;
 
 }
 
@@ -91,6 +94,10 @@ namespace LimelightConstants {
     constexpr static int LED_MODE_OFF = 1;
     constexpr static int TRACK_MODE_ON = 0;
     constexpr static int TRACK_MODE_OFF = 1;
+
+    // constants for limelight_state variable
+    constexpr static int STATE_ON = 1;
+    constexpr static int STATE_OFF = 0;    
 }
 
 

--- a/Competition/src/main/include/Constants.h
+++ b/Competition/src/main/include/Constants.h
@@ -20,3 +20,76 @@
 namespace OIConstants {
 constexpr int kDriverControllerPort = 1;
 }  // namespace OIConstants
+
+namespace DriveConstants {
+
+    // 1/2/3, 4/5/6 from pdp increasing towards intake
+    constexpr static int CAN_ID_LEFT_LEAD = 1;
+    constexpr static int CAN_ID_LEFT_FOLLOW_A = 2;
+    constexpr static int CAN_ID_LEFT_FOLLOW_B = 3;
+    constexpr static int CAN_ID_RIGHT_LEAD = 4;
+    constexpr static int CAN_ID_RIGHT_FOLLOW_A = 5;
+    constexpr static int CAN_ID_RIGHT_FOLLOW_B = 6;
+
+    constexpr auto kTrackwidth = 0.68_m;
+
+    constexpr double kWheelDiameterInches = 6;
+    constexpr double kGearRatio = 8.8;
+
+    constexpr static double kP = -0.01;
+    constexpr static double kI = 0;
+    constexpr static double kD = 0;
+    constexpr static double kFF = 0.00017543859;
+    constexpr static double kIz = 0;
+    constexpr static double MAX_RPM = 5700;
+    constexpr static double kMinOutput = -1.0;
+    constexpr static double kMaxOutput = 1.0;
+    constexpr static double kMinVel = 0;
+    constexpr static double kMaxVel = 1000;
+    constexpr static double kMaxAccel = 1500;
+    constexpr static double kAllError = 0;
+    constexpr static double kDeadband = 0.05;
+    // changed x and y deadband to .05 for testing
+    constexpr static double kDeadbandY = 0.05;
+    constexpr static double kDeadbandX = 0.05;
+    constexpr static double kDriveMultiplierX = 0.5;
+    constexpr static double kDriveMultiplierY = 1;
+    constexpr static double kDriveOffset = 1;
+
+}
+
+namespace RamseteConstants {
+
+    constexpr auto kMaxSpeed = 4.4_mps; // 4_mps
+    constexpr auto kMaxAcceleration = 4_mps_sq; //4_mps_sq;
+
+    constexpr double kRamseteB = 2;
+    constexpr double kRamseteZeta = 0.7;
+
+    // Convert rotations to meters using gear ratio and wheel diameter (converted to meters)
+    constexpr double kPositionConversionFactor = DriveConstants::kWheelDiameterInches * 0.0254 / DriveConstants::kGearRatio * M_PI;
+    // Convert rotations per minute to meters per second 
+    constexpr double kVelocityConversionFactor = kPositionConversionFactor / 60;
+
+    constexpr bool kGyroReversed = true;
+
+    constexpr auto kS = 0.146_V;
+    constexpr auto kV = 2.25 * 1_V * 1_s / 1_m;
+    constexpr auto kA = 0.315 * 1_V * 1_s * 1_s / 1_m;
+
+    constexpr double kPDriveVel = 3.09;
+
+    constexpr units::length::meter_t  kStartPos = 4.9_m;
+    //constexpr units::deg_t kStartAngularOffset = 15_deg;
+    constexpr units::length::meter_t  kCenterline = 0.94_m;
+
+}
+
+namespace LimelightConstants {
+    constexpr static int LED_MODE_ON = 3;
+    constexpr static int LED_MODE_OFF = 1;
+    constexpr static int TRACK_MODE_ON = 0;
+    constexpr static int TRACK_MODE_OFF = 1;
+}
+
+

--- a/Competition/src/main/include/Constants.h
+++ b/Competition/src/main/include/Constants.h
@@ -18,8 +18,10 @@
  */
 
 namespace OIConstants {
-constexpr int kDriverControllerPort = 1;
-}  // namespace OIConstants
+
+    constexpr int kDriverControllerPort = 1;
+    
+}
 
 namespace DriveConstants {
 
@@ -49,7 +51,6 @@ namespace DriveConstants {
     constexpr static double kMaxAccel = 1500;
     constexpr static double kAllError = 0;
     constexpr static double kDeadband = 0.05;
-    // changed x and y deadband to .05 for testing
     constexpr static double kDeadbandY = 0.05;
     constexpr static double kDeadbandX = 0.05;
     constexpr static double kDriveMultiplierX = 0.5;
@@ -60,8 +61,8 @@ namespace DriveConstants {
 
 namespace RamseteConstants {
 
-    constexpr auto kMaxSpeed = 4.4_mps; // 4_mps
-    constexpr auto kMaxAcceleration = 4_mps_sq; //4_mps_sq;
+    constexpr auto kMaxSpeed = 4.4_mps;
+    constexpr auto kMaxAcceleration = 4_mps_sq;
 
     constexpr double kRamseteB = 2;
     constexpr double kRamseteZeta = 0.7;

--- a/Competition/src/main/include/Drivetrain.h
+++ b/Competition/src/main/include/Drivetrain.h
@@ -46,11 +46,11 @@ class Drivetrain : public frc2::Subsystem {
 
   frc::ADIS16448_IMU imu{};
 
-  rev::CANPIDController m_leftPIDController;
-  rev::CANPIDController m_rightPIDController;
+  rev::CANPIDController m_leftPIDController = m_leftDriveLead.GetPIDController();;
+  rev::CANPIDController m_rightPIDController = m_rightDriveLead.GetPIDController();
 
-  rev::CANEncoder m_leftEncoder;
-  rev::CANEncoder m_rightEncoder;
+  rev::CANEncoder m_leftEncoder = m_leftDriveLead.GetEncoder();
+  rev::CANEncoder m_rightEncoder = m_rightDriveLead.GetEncoder();
 
   frc::DifferentialDriveOdometry m_odometry;
 

--- a/Competition/src/main/include/Drivetrain.h
+++ b/Competition/src/main/include/Drivetrain.h
@@ -75,8 +75,6 @@ class Drivetrain : public frc2::Subsystem {
   void ResetEncoders();
   void ResetOdometry(frc::Pose2d pose);
   void ResetIMU();
-  rev::CANEncoder& GetLeftEncoder();
-  rev::CANEncoder& GetRightEncoder();
   double GetEncAvgDistance();
   units::meter_t GetLeftDistance();
   units::meter_t GetRightDistance();
@@ -86,7 +84,6 @@ class Drivetrain : public frc2::Subsystem {
   frc::DifferentialDriveWheelSpeeds GetWheelSpeeds();
 
   void TankDriveVolts(units::volt_t leftVolts, units::volt_t rightVolts);
-  void ArcadeDrive(double leftInput, double rightInput);
   void RocketLeagueDrive(double straightInput, double reverseInput, double turnInput, bool limelightInput);
 
   void SetMultiplier(double multiplier);

--- a/Competition/src/main/include/Drivetrain.h
+++ b/Competition/src/main/include/Drivetrain.h
@@ -8,9 +8,60 @@
 #pragma once
 
 #include <frc2/command/Subsystem.h>
+#include <frc/SpeedControllerGroup.h>
+#include <rev/CANSparkMax.h>
+#include <rev/CANEncoder.h>
+
+#include <frc/kinematics/DifferentialDriveOdometry.h>
+#include <frc/geometry/Pose2d.h>
+#include <units/units.h>
+#include <frc/geometry/Rotation2d.h>
+#include <frc/kinematics/DifferentialDriveWheelSpeeds.h>
+#include <frc/controller/SimpleMotorFeedforward.h>
+#include <frc/kinematics/DifferentialDriveKinematics.h>
+#include <frc/trajectory/constraint/DifferentialDriveVoltageConstraint.h>
+#include <frc/trajectory/Trajectory.h>
+#include <frc/trajectory/TrajectoryGenerator.h>
+#include <adi/ADIS16448_IMU.h>
+
+#include <networktables/NetworkTableEntry.h>
+#include <networktables/NetworkTableInstance.h>
+#include <networktables/NetworkTable.h>
+#include <frc/livewindow/LiveWindow.h>
+#include <frc/smartdashboard/SmartDashboard.h>
+
+#include "Constants.h"
+
+#ifndef DRIVETRAIN_H
+#define DRIVETRAIN_H
 
 class Drivetrain : public frc2::Subsystem {
  private:
+  rev::CANSparkMax m_leftDriveLead;
+  rev::CANSparkMax m_leftDriveFollowA;
+  rev::CANSparkMax m_leftDriveFollowB;
+  rev::CANSparkMax m_rightDriveLead;
+  rev::CANSparkMax m_rightDriveFollowA;
+  rev::CANSparkMax m_rightDriveFollowB;
+
+  frc::ADIS16448_IMU imu{};
+
+  rev::CANPIDController m_leftPIDController = m_leftDriveLead.GetPIDController();
+  rev::CANPIDController m_rightPIDController = m_rightDriveLead.GetPIDController();
+
+  rev::CANEncoder m_leftEncoder = m_leftDriveLead.GetEncoder();
+  rev::CANEncoder m_rightEncoder = m_rightDriveLead.GetEncoder();
+
+  frc::DifferentialDriveOdometry m_odometry;
+
+  double directionY;
+  double straightValue;
+  double straightTarget;
+  double directionX;
+  double turnValue;
+  double turnTarget;
+
+  int limelight_state;
 
  public:
   Drivetrain();
@@ -19,4 +70,36 @@ class Drivetrain : public frc2::Subsystem {
 
   void Periodic() override;
 
+  void InitDrives(rev::CANSparkMax::IdleMode idleMode);
+
+  void ResetEncoders();
+  void ResetOdometry(frc::Pose2d pose);
+  void ResetIMU();
+  rev::CANEncoder& GetLeftEncoder();
+  rev::CANEncoder& GetRightEncoder();
+  double GetEncAvgDistance();
+  units::meter_t GetLeftDistance();
+  units::meter_t GetRightDistance();
+  double GetHeading();
+  double GetTurnRate();
+  frc::Pose2d GetPose();
+  frc::DifferentialDriveWheelSpeeds GetWheelSpeeds();
+
+  void TankDriveVolts(units::volt_t leftVolts, units::volt_t rightVolts);
+  void ArcadeDrive(double leftInput, double rightInput);
+  void RocketLeagueDrive(double straightInput, double reverseInput, double turnInput, bool limelightInput);
+
+  void SetMultiplier(double multiplier);
+  void Stop();
+
+  double boostMultiplier;
+
+  frc::DifferentialDriveKinematics kDriveKinematics;
+  frc::SimpleMotorFeedforward<units::meters> kSimpleMotorFeedforward;
+  frc::TrajectoryConfig kTrajectoryConfigF;
+  frc::TrajectoryConfig kTrajectoryConfigR;
+  frc::DifferentialDriveVoltageConstraint kDifferentialDriveVoltageConstraint;
+
 };
+
+#endif

--- a/Competition/src/main/include/Drivetrain.h
+++ b/Competition/src/main/include/Drivetrain.h
@@ -46,11 +46,11 @@ class Drivetrain : public frc2::Subsystem {
 
   frc::ADIS16448_IMU imu{};
 
-  rev::CANPIDController m_leftPIDController = m_leftDriveLead.GetPIDController();
-  rev::CANPIDController m_rightPIDController = m_rightDriveLead.GetPIDController();
+  rev::CANPIDController m_leftPIDController;
+  rev::CANPIDController m_rightPIDController;
 
-  rev::CANEncoder m_leftEncoder = m_leftDriveLead.GetEncoder();
-  rev::CANEncoder m_rightEncoder = m_rightDriveLead.GetEncoder();
+  rev::CANEncoder m_leftEncoder;
+  rev::CANEncoder m_rightEncoder;
 
   frc::DifferentialDriveOdometry m_odometry;
 
@@ -66,33 +66,55 @@ class Drivetrain : public frc2::Subsystem {
  public:
   Drivetrain();
 
+  // global method to return instance of drive subsystem
   static Drivetrain& GetInstance();
 
+  // loop method to always update odometry and state of subsystem
   void Periodic() override;
 
+  // initializes drive motors to proper configurations
   void InitDrives(rev::CANSparkMax::IdleMode idleMode);
 
+  // resets encoder values
   void ResetEncoders();
+  // resets odometry to given pose
   void ResetOdometry(frc::Pose2d pose);
+  // resets imu sensor
   void ResetIMU();
+  // return average of meters traveled left and right motors
   double GetEncAvgDistance();
+
+  // returns meters traveled by left motors
   units::meter_t GetLeftDistance();
+  // returns meters traveled by right motors
   units::meter_t GetRightDistance();
+
+  // returns imu heading in degrees
   double GetHeading();
+  // return angular velocity of drivetrain
   double GetTurnRate();
+
+  // returns pose of odometry (x, y, heading)
   frc::Pose2d GetPose();
   frc::DifferentialDriveWheelSpeeds GetWheelSpeeds();
 
+  // method to supply voltage to left and right motors individually
   void TankDriveVolts(units::volt_t leftVolts, units::volt_t rightVolts);
+  // tele-op rocket league controls drive method
   void RocketLeagueDrive(double straightInput, double reverseInput, double turnInput, bool limelightInput);
 
+  // sets boostMultiplier to 0.5 or 1 for drivetrain speed
   void SetMultiplier(double multiplier);
+
+  // stops all drive motors
   void Stop();
 
   double boostMultiplier;
 
   frc::DifferentialDriveKinematics kDriveKinematics;
   frc::SimpleMotorFeedforward<units::meters> kSimpleMotorFeedforward;
+
+  // need forward and reverse trajectory configs for when robot moves in spline forward/reverse
   frc::TrajectoryConfig kTrajectoryConfigF;
   frc::TrajectoryConfig kTrajectoryConfigR;
   frc::DifferentialDriveVoltageConstraint kDifferentialDriveVoltageConstraint;

--- a/Competition/vendordeps/ADIS16448.json
+++ b/Competition/vendordeps/ADIS16448.json
@@ -1,0 +1,32 @@
+{
+    "fileName": "ADIS16448.json",
+    "name": "ADIS16448-IMU",
+    "version": "2020.r3",
+    "uuid": "38c21ab6-aa8b-44bc-b844-8086c77f09ec",
+    "mavenUrls": [
+        "http://maven.highcurrent.io/maven"
+    ],
+    "jsonUrl": "http://maven.highcurrent.io/vendordeps/ADIS16448.json",
+    "javaDependencies": [
+        {
+            "groupId": "com.github.juchong",
+            "artifactId": "adis16448-java",
+            "version": "2020.r3"
+        }
+    ],
+    "jniDependencies": [],
+    "cppDependencies": [
+        {
+            "groupId": "com.github.juchong",
+            "artifactId": "adis16448-cpp",
+            "version": "2020.r3",
+            "libName": "libadis16448imu",
+            "headerClassifier": "headers",
+            "sharedLibrary": false,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "linuxathena"
+            ]
+        }
+    ]
+}

--- a/Competition/vendordeps/REVRobotics.json
+++ b/Competition/vendordeps/REVRobotics.json
@@ -1,0 +1,70 @@
+{
+    "cppDependencies": [
+        {
+            "artifactId": "SparkMax-cpp",
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "windowsx86",
+                "linuxaarch64bionic",
+                "linuxx86-64",
+                "linuxathena",
+                "linuxraspbian"
+            ],
+            "groupId": "com.revrobotics.frc",
+            "headerClassifier": "headers",
+            "libName": "SparkMax",
+            "sharedLibrary": false,
+            "skipInvalidPlatforms": true,
+            "version": "1.5.2"
+        },
+        {
+            "artifactId": "SparkMax-driver",
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "windowsx86",
+                "linuxaarch64bionic",
+                "linuxx86-64",
+                "linuxathena",
+                "linuxraspbian"
+            ],
+            "groupId": "com.revrobotics.frc",
+            "headerClassifier": "headers",
+            "libName": "SparkMaxDriver",
+            "sharedLibrary": false,
+            "skipInvalidPlatforms": true,
+            "version": "1.5.2"
+        }
+    ],
+    "fileName": "REVRobotics.json",
+    "javaDependencies": [
+        {
+            "artifactId": "SparkMax-java",
+            "groupId": "com.revrobotics.frc",
+            "version": "1.5.2"
+        }
+    ],
+    "jniDependencies": [
+        {
+            "artifactId": "SparkMax-driver",
+            "groupId": "com.revrobotics.frc",
+            "isJar": false,
+            "skipInvalidPlatforms": true,
+            "validPlatforms": [
+                "windowsx86-64",
+                "windowsx86",
+                "linuxaarch64bionic",
+                "linuxx86-64",
+                "linuxathena",
+                "linuxraspbian"
+            ],
+            "version": "1.5.2"
+        }
+    ],
+    "jsonUrl": "http://www.revrobotics.com/content/sw/max/sdk/REVRobotics.json",
+    "mavenUrls": [
+        "http://www.revrobotics.com/content/sw/max/sdk/maven/"
+    ],
+    "name": "REVRobotics",
+    "uuid": "3f48eb8c-50fe-43a6-9cb7-44c86353c4cb",
+    "version": "1.5.2"
+}


### PR DESCRIPTION
## Additions
### Ramsete
Added methods required for the Ramsete command to work
 - Odometry functionality
     - Initialized IMU & GetHeading method
     - Encoder get methods
 - Configuration Classes
     - Drive Kinematics
     - Trajectory config reverse and forward
     - Voltage constraints
 - Imported Constants from `constants.h`

### Drivetrain Setup
Initialized Motors and PID Controllers

 - Setup Lead-Follow motor configuration
 - Created PID controllers for lead motors
     - Initialized with constants from `constants.h`
 - Update odometry in periodic

### Constants
Created `constants.h` file for storing constant values

 - Limelight constants
     - LED Mode On & Off
     - Track Mode On & Off
 - Ramsete constants
     - Max Velocity
     - Max Acceleration
     - Conversion factors for accessing position and velocity
     - Tuned kS, kV, kA values
     - Offset constants for placement on field
 - Drivetrain constants
     - Motor IDs
     - Track Width
     - Feedforward and Feedback constants