### PR TITLE
Arm Subsystem Completed with New State Structure

### DIFF
--- a/Competition/src/main/cpp/Arm.cpp
+++ b/Competition/src/main/cpp/Arm.cpp
@@ -61,6 +61,7 @@ void Arm::assignOutputs() {
         }
         else {
             state.currentPower = 0;
+            resetState();
         }
     }
     else if (state.armState == ArmState::MANUAL) {
@@ -84,8 +85,12 @@ void Arm::assignOutputs() {
     armMtrRight.Set(ControlMode::PercentOutput, state.currentPower);
 }
 
+void Arm::setDisengage(bool disengage) {
+    state.disengage = disengage;
+}
+
 void Arm::resetState() {
-    state.disengage = false;
+    setDisengage(false);
     state.step1_startTime = -1;
     state.step2_startTime = -1;
 }

--- a/Competition/src/main/cpp/Arm.cpp
+++ b/Competition/src/main/cpp/Arm.cpp
@@ -1,0 +1,98 @@
+#include "Arm.h"
+
+Arm::Arm() : armMtrLeft{ArmConstants::TALON_ID_LEFT_ARM}, 
+             armMtrRight{ArmConstants::TALON_ID_RIGHT_ARM} {
+
+}
+
+Arm::Arm(frc::XboxController* controller) : operator_controller(controller), 
+                                            armMtrLeft{ArmConstants::TALON_ID_LEFT_ARM}, 
+                                            armMtrRight{ArmConstants::TALON_ID_RIGHT_ARM} {
+    InitArm();
+}
+
+Arm& Arm::GetInstance() {
+    static Arm instance;
+    return instance;
+}
+
+void Arm::Periodic() {
+    assessInputs();
+    assignOutputs();
+}
+
+void Arm::InitArm() {
+    armMtrLeft.ConfigFactoryDefault();
+    armMtrRight.ConfigFactoryDefault();
+
+    armMtrLeft.SetNeutralMode(NeutralMode::Brake);
+    armMtrRight.SetNeutralMode(NeutralMode::Brake);
+
+    armMtrLeft.SetInverted(false);
+    armMtrRight.SetInverted(false);
+
+    state.disengage = true;
+    state.step1_start_time = -1;
+    state.step2_start_time = -1;
+}
+
+void Arm::setDefaultState() {
+    state.arm_state = ArmState::DISABLED;
+}
+
+void Arm::assessInputs() {
+    if (state.disengage) {
+        state.arm_state = ArmState::DISENGAGE;
+    }
+    else if (std::abs(operator_controller->GetY(frc::GenericHID::kLeftHand)) > 0.05) {
+        state.arm_state = ArmState::MANUAL;
+    }
+}
+
+void Arm::assignOutputs() {
+    if (state.arm_state == ArmState::DISENGAGE) {
+        state.curr_time = state.timer.GetFPGATimestamp();
+
+        if (state.step1_start_time == -1) {
+            state.step1_start_time = state.curr_time;
+        }
+        else if (state.curr_time - state.step1_start_time <= 0.2) {
+            state.current_power = 0.4;
+        }
+        else if (state.step2_start_time == -1) {
+            state.step2_start_time = state.curr_time;
+        }
+        else if (state.curr_time - state.step2_start_time <= 0.3) {
+            state.current_power = 0.042;
+        }
+        else {
+            state.current_power = 0;
+
+            // reset code
+            // should reset code be in setDefaultState()?
+            state.disengage = false;
+            state.step1_start_time = -1;
+            state.step2_start_time = -1;
+        }
+    }
+    else if (state.arm_state == ArmState::MANUAL) {
+        if (std::abs(operator_controller->GetY(frc::GenericHID::kLeftHand)) <= 0.05) {
+            state.current_power = 0;
+        }
+        else if (std::abs(operator_controller->GetY(frc::GenericHID::kLeftHand)) < -0.05) {
+            state.current_power = -0.5;
+        }
+        else if (std::abs(operator_controller->GetY(frc::GenericHID::kLeftHand)) > 0.05 && std::abs(operator_controller->GetY(frc::GenericHID::kLeftHand)) < 0.85) {
+            state.current_power = -0.042;
+        }
+        else {
+            state.current_power = 0.1;
+        }
+    }
+    else {
+        state.current_power = 0;
+    }
+    armMtrLeft.Set(ControlMode::PercentOutput, state.current_power);
+    armMtrRight.Set(ControlMode::PercentOutput, state.current_power);
+
+}

--- a/Competition/src/main/cpp/Arm.cpp
+++ b/Competition/src/main/cpp/Arm.cpp
@@ -79,10 +79,10 @@ void Arm::assignOutputs() {
         if (std::abs(operator_controller->GetY(frc::GenericHID::kLeftHand)) <= 0.05) {
             state.current_power = 0;
         }
-        else if (std::abs(operator_controller->GetY(frc::GenericHID::kLeftHand)) < -0.05) {
+        else if (operator_controller->GetY(frc::GenericHID::kLeftHand) < -0.05) {
             state.current_power = -0.5;
         }
-        else if (std::abs(operator_controller->GetY(frc::GenericHID::kLeftHand)) > 0.05 && std::abs(operator_controller->GetY(frc::GenericHID::kLeftHand)) < 0.85) {
+        else if (operator_controller->GetY(frc::GenericHID::kLeftHand) > 0.05 && operator_controller->GetY(frc::GenericHID::kLeftHand) < 0.85) {
             state.current_power = -0.042;
         }
         else {

--- a/Competition/src/main/cpp/Arm.cpp
+++ b/Competition/src/main/cpp/Arm.cpp
@@ -1,14 +1,14 @@
 #include "Arm.h"
 
-Arm::Arm() : armMtrLeft{ArmConstants::TALON_ID_LEFT_ARM}, 
+Arm::Arm() : operator_controller(NULL),
+             armMtrLeft{ArmConstants::TALON_ID_LEFT_ARM}, 
              armMtrRight{ArmConstants::TALON_ID_RIGHT_ARM} {
-
+    InitArm();
 }
 
-Arm::Arm(frc::XboxController* controller) : operator_controller(controller), 
-                                            armMtrLeft{ArmConstants::TALON_ID_LEFT_ARM}, 
-                                            armMtrRight{ArmConstants::TALON_ID_RIGHT_ARM} {
-    InitArm();
+void Arm::setController(frc::XboxController* controller)
+{
+    operator_controller = controller;
 }
 
 Arm& Arm::GetInstance() {
@@ -41,6 +41,10 @@ void Arm::setDefaultState() {
 }
 
 void Arm::assessInputs() {
+    // Prevent controller segfault
+    if (!operator_controller)
+        return;
+
     if (state.disengage) {
         state.arm_state = ArmState::DISENGAGE;
     }

--- a/Competition/src/main/cpp/Robot.cpp
+++ b/Competition/src/main/cpp/Robot.cpp
@@ -39,7 +39,7 @@ void Robot::DisabledPeriodic() {}
  * RobotContainer} class.
  */
 void Robot::AutonomousInit() {
-  m_container.m_arm.state.disengage = true;
+  m_container.m_arm.setDisengage(true);
 
   m_autonomousCommand = m_container.GetAutonomousCommand();
 

--- a/Competition/src/main/cpp/Robot.cpp
+++ b/Competition/src/main/cpp/Robot.cpp
@@ -39,6 +39,8 @@ void Robot::DisabledPeriodic() {}
  * RobotContainer} class.
  */
 void Robot::AutonomousInit() {
+  m_container.m_arm.state.disengage = true;
+
   m_autonomousCommand = m_container.GetAutonomousCommand();
 
   if (m_autonomousCommand != nullptr) {

--- a/Competition/src/main/cpp/Robot.cpp
+++ b/Competition/src/main/cpp/Robot.cpp
@@ -29,6 +29,7 @@ void Robot::RobotPeriodic() { frc2::CommandScheduler::GetInstance().Run(); }
  */
 void Robot::DisabledInit() {
   m_container.m_shooter.setDefaultState();
+  m_container.m_arm.setDefaultState();
 }
 
 void Robot::DisabledPeriodic() {}

--- a/Competition/src/main/cpp/RobotContainer.cpp
+++ b/Competition/src/main/cpp/RobotContainer.cpp
@@ -16,6 +16,7 @@ RobotContainer::RobotContainer() {
 
 void RobotContainer::ConfigureButtonBindings() {
   // Configure your button bindings here
+  m_arm.setController(&m_GamepadOperator);
 }
 
 frc2::Command* RobotContainer::GetAutonomousCommand() {

--- a/Competition/src/main/include/Arm.h
+++ b/Competition/src/main/include/Arm.h
@@ -12,18 +12,15 @@
 
 class Arm : public ValorSubsystem {
   public:
-    Arm();
     Arm(frc::XboxController*);
-
-    static Arm& GetInstance();
-
-    void Periodic();
 
     void InitArm();
 
     void setDefaultState();
     void assessInputs();
     void assignOutputs();
+
+    void resetState();
 
     enum ArmState {
         DISABLED, 
@@ -40,6 +37,8 @@ class Arm : public ValorSubsystem {
         double curr_time;
         double step1_start_time;
         double step2_start_time;
+
+        double leftJoystickY;
     } state;
 
   private:

--- a/Competition/src/main/include/Arm.h
+++ b/Competition/src/main/include/Arm.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "ValorSubsystem.h"
+#include "Constants.h"
+
+#include <frc/XboxController.h>
+#include <frc/Timer.h>
+#include <ctre/Phoenix.h>
+
+#ifndef ARM_H
+#define ARM_H
+
+class Arm : public ValorSubsystem {
+  public:
+    Arm();
+    Arm(frc::XboxController*);
+
+    static Arm& GetInstance();
+
+    void Periodic();
+
+    void InitArm();
+
+    void setDefaultState();
+    void assessInputs();
+    void assignOutputs();
+
+    enum ArmState {
+        DISABLED, 
+        DISENGAGE, 
+        MANUAL
+    };
+
+    struct x {
+        ArmState arm_state;
+
+        frc::Timer timer;
+        bool disengage;
+        double current_power;
+        double curr_time;
+        double step1_start_time;
+        double step2_start_time;
+    } state;
+
+  private:
+    TalonSRX armMtrLeft;
+    TalonSRX armMtrRight;
+
+    frc::XboxController* operator_controller;
+};
+
+#endif

--- a/Competition/src/main/include/Arm.h
+++ b/Competition/src/main/include/Arm.h
@@ -13,7 +13,7 @@
 class Arm : public ValorSubsystem {
   public:
     Arm();
-    Arm(frc::XboxController*);
+    void setController(frc::XboxController*);
 
     static Arm& GetInstance();
 

--- a/Competition/src/main/include/Arm.h
+++ b/Competition/src/main/include/Arm.h
@@ -21,6 +21,7 @@ class Arm : public ValorSubsystem {
         void assessInputs();
         void assignOutputs();
 
+        void setDisengage(bool disengage);
         void resetState();
 
         enum ArmState {

--- a/Competition/src/main/include/Constants.h
+++ b/Competition/src/main/include/Constants.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <units/units.h>
+
 /**
  * The Constants header provides a convenient place for teams to hold robot-wide
  * numerical or boolean constants.  This should not be used for any other
@@ -99,5 +101,11 @@ namespace LimelightConstants {
     constexpr static int STATE_ON = 1;
     constexpr static int STATE_OFF = 0;    
 }
+
+namespace ArmConstants {
+    constexpr static int TALON_ID_LEFT_ARM = 9;
+    constexpr static int TALON_ID_RIGHT_ARM = 10;
+}
+
 
 

--- a/Competition/src/main/include/Constants.h
+++ b/Competition/src/main/include/Constants.h
@@ -20,9 +20,8 @@
  */
 
 namespace OIConstants {
-
-    constexpr int kDriverControllerPort = 1;
-    
+    constexpr static int GAMEPAD_BASE_LOCATION = 1;
+    constexpr static int GAMEPAD_OPERATOR_LOCATION = 0;
 }
 
 namespace DriveConstants {

--- a/Competition/src/main/include/RobotContainer.h
+++ b/Competition/src/main/include/RobotContainer.h
@@ -13,6 +13,7 @@
 
 #include "Drivetrain.h"
 #include "Shooter.h"
+#include "Arm.h"
 
 /**
  * This class is where the bulk of the robot should be declared.  Since
@@ -29,6 +30,7 @@ class RobotContainer {
  
   Drivetrain& m_drivetrain = Drivetrain::GetInstance();
   Shooter& m_shooter = (Shooter&)Shooter::GetInstance();
+  Arm& m_arm = (Arm&) Arm::GetInstance();
 
  private:
 

--- a/Competition/src/main/include/RobotContainer.h
+++ b/Competition/src/main/include/RobotContainer.h
@@ -25,6 +25,9 @@
 class RobotContainer {
  public:
   RobotContainer();
+  
+  frc::XboxController m_GamepadDriver{OIConstants::GAMEPAD_BASE_LOCATION};
+  frc::XboxController m_GamepadOperator{OIConstants::GAMEPAD_OPERATOR_LOCATION};
 
   frc2::Command* GetAutonomousCommand();
  

--- a/Competition/vendordeps/Phoenix.json
+++ b/Competition/vendordeps/Phoenix.json
@@ -1,0 +1,180 @@
+{
+    "fileName": "Phoenix.json",
+    "name": "CTRE-Phoenix",
+    "version": "5.18.3",
+    "uuid": "ab676553-b602-441f-a38d-f1296eff6537",
+    "mavenUrls": [
+        "http://devsite.ctr-electronics.com/maven/release/"
+    ],
+    "jsonUrl": "http://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/Phoenix-latest.json",
+    "javaDependencies": [
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "api-java",
+            "version": "5.18.3"
+        },
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "wpiapi-java",
+            "version": "5.18.3"
+        }
+    ],
+    "jniDependencies": [
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "cci",
+            "version": "5.18.3",
+            "isJar": false,
+            "skipInvalidPlatforms": true,
+            "validPlatforms": [
+                "linuxathena",
+                "windowsx86-64",
+                "linuxx86-64"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "diagnostics",
+            "version": "5.18.3",
+            "isJar": false,
+            "skipInvalidPlatforms": true,
+            "validPlatforms": [
+                "linuxathena",
+                "windowsx86-64",
+                "linuxx86-64"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "canutils",
+            "version": "5.18.3",
+            "isJar": false,
+            "skipInvalidPlatforms": true,
+            "validPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "platform-stub",
+            "version": "5.18.3",
+            "isJar": false,
+            "skipInvalidPlatforms": true,
+            "validPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "core",
+            "version": "5.18.3",
+            "isJar": false,
+            "skipInvalidPlatforms": true,
+            "validPlatforms": [
+                "linuxathena",
+                "windowsx86-64",
+                "linuxx86-64"
+            ]
+        }
+    ],
+    "cppDependencies": [
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "wpiapi-cpp",
+            "version": "5.18.3",
+            "libName": "CTRE_Phoenix_WPI",
+            "headerClassifier": "headers",
+            "sharedLibrary": false,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "linuxathena",
+                "windowsx86-64",
+                "linuxx86-64"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "api-cpp",
+            "version": "5.18.3",
+            "libName": "CTRE_Phoenix",
+            "headerClassifier": "headers",
+            "sharedLibrary": false,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "linuxathena",
+                "windowsx86-64",
+                "linuxx86-64"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "cci",
+            "version": "5.18.3",
+            "libName": "CTRE_PhoenixCCI",
+            "headerClassifier": "headers",
+            "sharedLibrary": false,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "linuxathena",
+                "windowsx86-64",
+                "linuxx86-64"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "diagnostics",
+            "version": "5.18.3",
+            "libName": "CTRE_PhoenixDiagnostics",
+            "headerClassifier": "headers",
+            "sharedLibrary": false,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "linuxathena",
+                "windowsx86-64",
+                "linuxx86-64"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "canutils",
+            "version": "5.18.3",
+            "libName": "CTRE_PhoenixCanutils",
+            "headerClassifier": "headers",
+            "sharedLibrary": false,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "platform-stub",
+            "version": "5.18.3",
+            "libName": "CTRE_PhoenixPlatform",
+            "headerClassifier": "headers",
+            "sharedLibrary": false,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "core",
+            "version": "5.18.3",
+            "libName": "CTRE_PhoenixCore",
+            "headerClassifier": "headers",
+            "sharedLibrary": false,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "linuxathena",
+                "windowsx86-64",
+                "linuxx86-64"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
## Arm Subsystem General Structure

- Chooses between 3 states to perform particular actions respective to the state
   - ArmState::DISABLED
   - ArmState::DISENGAGE
   - ArmState::MANUAL
- Runs all gather-info/output actions in Periodic() loop (every 20 ms)
- GetInstance() allows other classes to utilize the Arm subsystem without creating new memory each time called
- x struct variable (declared as state in .h) used to keep track of loop-to-loop information
   - current state
   - current power
   - disengage boolean indicator
   - disengage helper variables
      - step 1 start time and step 2 start time of disengage process
   - frc::Timer object
   - current FPGA time


## Initializing the Arm Subsystem

- Takes in pointer to XboxController object as constructor parameter to allow for reading of gamepad
- XboxController member variable is set to pointer parameter in initializer list
- InitArm() initializes Talon SRX motors for arm and resets other state struct variables
- setDefaultState() is called in Robot.cpp in DisabledInit period to ensure Arm is in ArmState::DISABLED


## Periodic Loop

- Calls AssessInputs() and AssignOutputs() methods here


### AssessInputs()

- Reads input values and assigns the Arm to one of the states
- Uses state.disengage boolean to decide if Arm should be in auto disengage process
- Uses operator gamepad left stick Y axis to decide if Arm should be in tele-op manual mode
* Disabled state is controlled outside of Periodic() loop (setDefaultState())


### AssignOutputs()

- Reads states and sets desired power for Arm motors
- Uses state.arm_state to see which state Arm subsystem is currently in

#### Disengage Process

- Process is carried out at start of auto period to bring arm down from pin to robot frame
- Uses -1 values for step1/step2 start time variables to check if step1/step2 have been started
- Uses state.timer.getFPGATimestamp() for accurate reading at beginning of each loop iteration

**Time values have not been tested yet

1. Raise arm slightly out of pin (upwards power for very short time)
2. Lower arm carefully until arm reaches frame (downwards power for little longer time)

#### Manual Arm Control

- State meant for full tele-op period

Arm Manual Control Checklist

1. If joystick hasn't moved, set 0
2. If joystick is pulled down to any amount less than -0.05, set -0.5
3. If joystick pushed up between 0.05 and 0.85, set -0.042
4. Else (pushed up to full) set 0.1