### PR TITLE
Feature init reset

### DIFF
--- a/Competition/src/main/cpp/ValorSubsystem.cpp
+++ b/Competition/src/main/cpp/ValorSubsystem.cpp
@@ -16,23 +16,27 @@ void ValorSubsystem::Periodic() {
     assignOutputs();
 }
 
-ValorSubsystem& ValorSubsystem::GetInstance()
-{
+ValorSubsystem& ValorSubsystem::GetInstance() {
     static ValorSubsystem instance;
     return instance;
 }
 
-void ValorSubsystem::setDefaultState()
-{
+void ValorSubsystem::init() {
+    // init subsystem
+}
+
+void ValorSubsystem::setDefaultState() {
     // Assign default states
 }
 
-void ValorSubsystem::assessInputs()
-{
+void ValorSubsystem::assessInputs() {
     // Assess inputs and assign states
 }
 
-void ValorSubsystem::assignOutputs()
-{
+void ValorSubsystem::assignOutputs() {
     // Assess states and assign outputs
+}
+
+void ValorSubsystem::resetState() {
+    // reset state
 }

--- a/Competition/src/main/include/ValorSubsystem.h
+++ b/Competition/src/main/include/ValorSubsystem.h
@@ -10,23 +10,29 @@
 #include <frc2/command/SubsystemBase.h>
 
 class ValorSubsystem : public frc2::Subsystem {
-public:
-  ValorSubsystem();
-
-  void Periodic();
-
-  static ValorSubsystem& GetInstance();
-
-  // Rules:
-  //   * Never read 'state', can only write 'state'
-  virtual void setDefaultState();
-
-  // Rules:
-  //   * Never read 'state', can only write 'state'
-  virtual void assessInputs();
-
-  // Rules:
-  //   * Never write another subsystem's 'state', only can read
-  //   * Can read or write 'state'
-  virtual void assignOutputs();
+    public:
+        ValorSubsystem();
+        
+        void Periodic();
+        
+        static ValorSubsystem& GetInstance();
+        
+        // should initialize subsystem's devices
+        virtual void init();
+        
+        // Rules:
+        //   * Never read 'state', can only write 'state'
+        virtual void setDefaultState();
+        
+        // Rules:
+        //   * Never read 'state', can only write 'state'
+        virtual void assessInputs();
+        
+        // Rules:
+        //   * Never write another subsystem's 'state', only can read
+        //   * Can read or write 'state'
+        virtual void assignOutputs();
+        
+        // should reset the subsystem state to robot setup position
+        virtual void resetState();
 };


### PR DESCRIPTION
## Methods Added to Base Class

### init()

- used to setup configurations for subsystem's devices

### resetState()

- used to set any state variables to default values

